### PR TITLE
Folders with spaces will error out

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -23,7 +23,7 @@ module.exports = generators.Base.extend({
                 type: 'input',
                 name: 'name',
                 message: 'Your project name',
-                default: this.appname // Default to current folder name
+                default: 'react-engine-generator' // Default to current folder name
             },
             {
                 type: 'list',


### PR DESCRIPTION
If your project name is called `react engine test` and you run the yeoman generator, npm will fail out on you. 

Possible solutions to avoid this is to write a helper function to eliminate spaces, but I felt like setting a default name for simplicity's sake.