### PR TITLE
migrate from kraken-devtools to construx

### DIFF
--- a/app/templates/common/kraken/package.json
+++ b/app/templates/common/kraken/package.json
@@ -10,7 +10,8 @@
   "dependencies": {
     "engine-munger": "^0.2.0",
     "express": "^4.3.0",
-    "kraken-devtools": "^1.0.0",
+    "construx": "~0.0.1",
+    "construx-copier": "~0.0.1",
     "kraken-js": "^1.0.1",
     "localizr": "^0.1.6",
     "node-jsx": "^0.13.3",

--- a/app/templates/kraken/config/development.json
+++ b/app/templates/kraken/config/development.json
@@ -1,19 +1,16 @@
 {
-    
-
     "middleware": {
-
-        "devtools": {
+        "construx": {
             "enabled": true,
             "priority": 35,
             "module": {
-                "name": "kraken-devtools",
+                "name": "construx",
                 "arguments": [
                     "path:./public",
                     "path:./.build",
-                    {   
+                    {
                         "copier": {
-                            "module": "kraken-devtools/plugins/copier",
+                            "module": "construx-copier",
                             "files": "**/*"
                         }
                     }


### PR DESCRIPTION
kraken-devtools is deprecated in favor of the construx modules. Please see:
http://krakenjs.com/2016/03/16/announcing-construx-development-middleware.html